### PR TITLE
Fix timezone offset in history lookup

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -25,8 +25,8 @@ def normalize_url(url):
     return normalized
 
 def load_history(history_path):
-    # 30日前のWebkit時間を計算
-    time_limit = chrome_time(datetime.now() - timedelta(days=30))
+    # 30日前のWebkit時間を計算 (History timestamps are stored in UTC)
+    time_limit = chrome_time(datetime.utcnow() - timedelta(days=30))
 
     tmp_path = history_path.with_name("History_copy")
     tmp_path.write_bytes(history_path.read_bytes())


### PR DESCRIPTION
## Summary
- correct timezone when querying visit history

## Testing
- `python -m py_compile analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_684d4686da00832b8ad3d32e9121b2f4